### PR TITLE
Allow asking for any variant on an ab_test

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,9 @@ end
 # calls #variant underneath, results of that call are cached
 puts 'red button' if ab.test.red_button?
 
+# non existant variants return false
+puts 'this will not get printed' if ab.test.there_is_no_button?
+
 # both start_at and end_at dates are accessible
 puts 'newbie button' if user.created_at > ab.test.start_at && ab.test.for_newbies?
 ```

--- a/README.md
+++ b/README.md
@@ -20,6 +20,11 @@ ab = Ab::Tests.new(configuration, identifier)
 Ab::Tests.before_picking_variant { |test| puts "picking variant for #{test}" }
 Ab::Tests.after_picking_variant { |test, variant| puts "#{variant_name}" }
 
+# by default messages are logged to null logger. Can be changed by setting your own logger:
+Ab.configure do |config|
+  config.logger = Logger.new($stdout)
+end
+
 # ab.test never returns nil, but #variant can
 case ab.test.variant
 when 'red_button'

--- a/lib/ab.rb
+++ b/lib/ab.rb
@@ -1,6 +1,8 @@
 require 'securerandom'
 require 'date'
+require 'logger'
 require 'ab/version'
+require 'ab/configuration'
 require 'ab/missing_variant'
 require 'ab/null_test'
 require 'ab/variant'

--- a/lib/ab.rb
+++ b/lib/ab.rb
@@ -1,6 +1,7 @@
 require 'securerandom'
 require 'date'
 require 'ab/version'
+require 'ab/missing_variant'
 require 'ab/null_test'
 require 'ab/variant'
 require 'ab/test'

--- a/lib/ab/assigned_test.rb
+++ b/lib/ab/assigned_test.rb
@@ -1,5 +1,7 @@
 module Ab
   class AssignedTest
+    include Ab::MissingVariant
+
     def initialize(test, id)
       @test, @id = test, id
       variants.each do |name|

--- a/lib/ab/configuration.rb
+++ b/lib/ab/configuration.rb
@@ -1,0 +1,22 @@
+module Ab
+  class << self
+    attr_writer :config
+
+    def config
+      @config ||= Config.new
+    end
+
+    def configure
+      @config ||= Config.new
+      yield(@config)
+    end
+  end
+
+  class Config
+    attr_accessor :logger
+
+    def initialize
+      @logger = Logger.new(nil)
+    end
+  end
+end

--- a/lib/ab/missing_variant.rb
+++ b/lib/ab/missing_variant.rb
@@ -1,7 +1,12 @@
 module Ab
   module MissingVariant
     def method_missing(meth, *args, &block)
-      variant_method?(meth) ? false : super
+      if variant_method?(meth)
+        log_missing_variant(meth)
+        false
+      else
+        super
+      end
     end
 
     def respond_to_missing?(meth, *)
@@ -12,6 +17,10 @@ module Ab
 
     def variant_method?(meth)
       meth.to_s.end_with?('?')
+    end
+
+    def log_missing_variant(meth)
+      Ab.config.logger.debug("[AB_testing] Checking non-existing variant: #{meth}")
     end
   end
 end

--- a/lib/ab/missing_variant.rb
+++ b/lib/ab/missing_variant.rb
@@ -1,0 +1,17 @@
+module Ab
+  module MissingVariant
+    def method_missing(meth, *args, &block)
+      variant_method?(meth) ? false : super
+    end
+
+    def respond_to_missing?(meth, *)
+      variant_method?(meth) ? true : super
+    end
+
+    private
+
+    def variant_method?(meth)
+      meth.to_s.end_with?('?')
+    end
+  end
+end

--- a/lib/ab/null_test.rb
+++ b/lib/ab/null_test.rb
@@ -1,5 +1,7 @@
 module Ab
   class NullTest
+    include Ab::MissingVariant
+
     def variant
     end
 
@@ -9,14 +11,6 @@ module Ab
 
     def end_at
       Test::DEFAULT_END_AT
-    end
-
-    def method_missing(meth, *args, &block)
-      meth.to_s.end_with?('?') ? false : super
-    end
-
-    def respond_to_missing?(meth)
-      meth.to_s.end_with?('?') ? true : super
     end
   end
 end

--- a/spec/assigned_test_spec.rb
+++ b/spec/assigned_test_spec.rb
@@ -18,8 +18,12 @@ module Ab
 
     context 'with non existent variant' do
       let(:variants) { [OpenStruct.new(name: 'enabled', accumulated_chance_weight: 2)] }
+      let(:message) { '[AB_testing] Checking non-existing variant: disabled?' }
+
+      before { Ab.config.logger.should_receive(:debug).with(message) }
 
       subject { assigned_test.disabled? }
+
       it { should be false }
     end
 

--- a/spec/assigned_test_spec.rb
+++ b/spec/assigned_test_spec.rb
@@ -16,6 +16,13 @@ module Ab
     let(:buckets) { 1..1000 }
     let(:thousand_variants) { 1.upto(1000).map { |i| AssignedTest.new(test, i).variant } }
 
+    context 'with non existent variant' do
+      let(:variants) { [OpenStruct.new(name: 'enabled', accumulated_chance_weight: 2)] }
+
+      subject { assigned_test.disabled? }
+      it { should be false }
+    end
+
     describe '#variant' do
       subject { assigned_test.variant }
 


### PR DESCRIPTION
If ab config changes variant configuration for an ab test,
ab lib used to throw errors if `ab_test.some_variant?` code
was invoked. Now it returns false.

Java/Objective-C implementations seem to behave in similar way.

cc @mmozuras 