### PR TITLE
Make AB test initialization defer work when possible

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,6 @@ sudo: required
 dist: trusty
 language: ruby
 rvm:
-- 1.9.3
-- 2.0.0
-- 2.1
-- 2.2
-- 2.3.0
+- 2.4.2
+- 2.5.3
+- 2.6.1

--- a/lib/ab/assigned_test.rb
+++ b/lib/ab/assigned_test.rb
@@ -5,9 +5,6 @@ module Ab
     def initialize(test, id)
       @test = test
       @id = id
-      variants.each do |name|
-        define_singleton_method("#{name}?") { name == variant }
-      end
     end
 
     class << self
@@ -19,6 +16,12 @@ module Ab
       def after_picking_variant(&block)
         @after = block
       end
+    end
+
+    def method_missing(name, *args, &block)
+      variant_query = name.to_s[0..-2]
+      return variant == variant_query if variant_method?(name) && variants.include?(variant_query)
+      super
     end
 
     def variant(run_callbacks = true)


### PR DESCRIPTION
Right now a lot of work is done on `Ab::Tests.new` at once. In our biggest portal it takes close to 1ms to initialize this instance.

Deferred some of the work, more is possible but would require bigger rewrite.

My benchmarks with production AB test configs show a 100x improvement.

Change should be transparent and require no changes in clients.

@raimondasv